### PR TITLE
Fix flatted security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3432,9 +3432,10 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/fs.realpath": {
@@ -8304,14 +8305,14 @@
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "peer": true,
       "requires": {
-        "flatted": "^3.1.0",
+        "flatted": ">=3.4.2",
         "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "peer": true
     },
     "fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "overrides": {
     "braces": ">=3.0.3",
     "cross-spawn": ">=7.0.5",
-    "rollup": ">=4.22.4"
+    "rollup": ">=4.22.4",
+    "flatted": ">=3.4.2"
   },
   "devDependencies": {
     "@types/eslint": "^8.56.4",


### PR DESCRIPTION
## Summary
- Override `flatted` to `>=3.4.2` to fix two high-severity vulnerabilities:
  - **#27**: Unbounded recursion DoS in `parse()`
  - **#28**: Prototype Pollution via `parse()`
- Follows existing override pattern for braces, cross-spawn, and rollup

## Test plan
- [x] `npm ls flatted` confirms version 3.4.2
- [x] `npm test` passes (all 10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)