### PR TITLE
chore: add explicit workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Run Tests
 
 on: [push]
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Workflow Permissions — automated PR

Adds `permissions: read-all` to every workflow that lacked a top-level `permissions:` key, so jobs no longer silently inherit the repository or org default (which may be full write access).

> [!WARNING]
> **CI jobs that need write access will fail** until you add explicit job-level permissions (e.g. `contents: write`, `pull-requests: write`). See [GitHub docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

> [!TIP]
> **You should narrow permissions further.** The ideal setup is `permissions: {}` at the top level and explicit grants on each job that needs them. `read-all` is the automated baseline — feel free to tighten it. See [available permission scopes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).

### Checklist

- [ ] Check each job for write operations and add job-level `permissions:` where needed
- [ ] CI is green
- [ ] **Merge into `master`**
