### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @livechat/app-core-web-desktop


### PR DESCRIPTION
## Add CODEOWNERS — automated PR

This PR was opened automatically to add a `.github/CODEOWNERS` file so that GitHub can auto-assign reviewers based on code ownership.

### What changed

A new `.github/CODEOWNERS` file was created:

```
* @livechat/app-core-web-desktop
```

This means every file in the repository is owned by `@livechat/app-core-web-desktop`. Members of that team will be auto-requested for review on every pull request.

### Review checklist

- [ ] Confirm that `@livechat/app-core-web-desktop` is the correct owning team for this repo
- [ ] Add more specific path-based rules if needed (e.g. `src/api/ @livechat/other-team`)
- [ ] **Merge into `master`**